### PR TITLE
IPAM: add allocator provider for Volcengine

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -85,6 +85,7 @@ require (
 	github.com/tidwall/sjson v1.2.5
 	github.com/vishvananda/netlink v1.2.1-beta.2.0.20231127184239-0ced8385386a
 	github.com/vishvananda/netns v0.0.4
+	github.com/volcengine/volcengine-go-sdk v1.0.124
 	go.etcd.io/etcd/api/v3 v3.5.11
 	go.etcd.io/etcd/client/pkg/v3 v3.5.11
 	go.etcd.io/etcd/client/v3 v3.5.11
@@ -239,6 +240,7 @@ require (
 	github.com/tidwall/pretty v1.2.0 // indirect
 	github.com/tklauser/go-sysconf v0.3.11 // indirect
 	github.com/tklauser/numcpus v0.6.0 // indirect
+	github.com/volcengine/volc-sdk-golang v1.0.23 // indirect
 	github.com/yusufpapurcu/wmi v1.2.3 // indirect
 	github.com/zeebo/errs v1.3.0 // indirect
 	gitlab.com/golang-commonmark/puny v0.0.0-20191124015043-9f83538fa04f // indirect

--- a/go.sum
+++ b/go.sum
@@ -71,6 +71,7 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkY
 github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
+github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/aws/aws-sdk-go-v2 v1.24.0 h1:890+mqQ+hTpNuw0gGP6/4akolQkSToDJgHfQE7AwGuk=
 github.com/aws/aws-sdk-go-v2 v1.24.0/go.mod h1:LNh45Br1YAkEKaAqvmE1m8FUx6a5b/V0oAKV7of29b4=
 github.com/aws/aws-sdk-go-v2/config v1.26.1 h1:z6DqMxclFGL3Zfo+4Q0rLnAZ6yVkzCRxhRMsiRQnD1o=
@@ -347,6 +348,7 @@ github.com/google/renameio/v2 v2.0.0 h1:UifI23ZTGY8Tt29JbYFiuyIU3eX+RNFtUwefq9qA
 github.com/google/renameio/v2 v2.0.0/go.mod h1:BtmJXm5YlszgC+TD4HOEEUFgkJP3nLxehU6hfe7jRt4=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.4.0 h1:MtMxsa51/r9yyhkyLsVeVt0B+BGQZzpQiTQ4eHZ8bc4=
 github.com/google/uuid v1.4.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
@@ -694,6 +696,10 @@ github.com/vishvananda/netlink v1.2.1-beta.2.0.20231127184239-0ced8385386a/go.mo
 github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
 github.com/vishvananda/netns v0.0.4 h1:Oeaw1EM2JMxD51g9uhtC0D7erkIjgmj8+JZc26m1YX8=
 github.com/vishvananda/netns v0.0.4/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
+github.com/volcengine/volc-sdk-golang v1.0.23 h1:anOslb2Qp6ywnsbyq9jqR0ljuO63kg9PY+4OehIk5R8=
+github.com/volcengine/volc-sdk-golang v1.0.23/go.mod h1:AfG/PZRUkHJ9inETvbjNifTDgut25Wbkm2QoYBTbvyU=
+github.com/volcengine/volcengine-go-sdk v1.0.124 h1:Nqsb7ahyVviy7RcYPUle36Kq+e1OhvX6npIXFWlhmQo=
+github.com/volcengine/volcengine-go-sdk v1.0.124/go.mod h1:oht5AKDJsk0fY6tV2ViqaVlOO14KSRmXZlI8ikK60Tg=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=
 github.com/xdg-go/scram v1.1.1/go.mod h1:RaEWvsqvNKKvBPvcKeFjrG2cJqOkHTiyTpzz23ni57g=
 github.com/xdg-go/scram v1.1.2/go.mod h1:RT/sEzTbU5y00aCK8UOx6R7YryM0iF1N2MOmC3kKLN4=

--- a/operator/cmd/provider_volcengine_flags.go
+++ b/operator/cmd/provider_volcengine_flags.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+//go:build ipam_provider_volcengine
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	operatorOption "github.com/cilium/cilium/operator/option"
+	"github.com/cilium/cilium/pkg/defaults"
+	"github.com/cilium/cilium/pkg/option"
+)
+
+func init() {
+	FlagsHooks = append(FlagsHooks, new(volcengineFlagsHooks))
+}
+
+type volcengineFlagsHooks struct{}
+
+func (h *volcengineFlagsHooks) RegisterProviderFlag(cmd *cobra.Command, vp *viper.Viper) {
+	flags := cmd.Flags()
+
+	flags.Var(option.NewNamedMapOptions(operatorOption.VolcengineENIGCTags, &operatorOption.Config.VolcengineENIGCTags, nil),
+		operatorOption.VolcengineENIGCTags, "Additional tags attached to Volcengine ENIs created by Cilium. Dangling ENIs with this tag will be garbage collected")
+	option.BindEnv(vp, operatorOption.VolcengineENIGCTags)
+
+	flags.Duration(operatorOption.VolcengineENIGCInterval, defaults.ENIGarbageCollectionInterval,
+		"Interval for garbage collection of unattached Volcengine ENIs. Set to 0 to disable")
+	option.BindEnv(vp, operatorOption.VolcengineENIGCInterval)
+
+	flags.String(operatorOption.VolcengineVPCID, "", "Specific VPC ID for Volcengine ENI. If not set use same VPC as operator")
+	option.BindEnv(vp, operatorOption.VolcengineVPCID)
+
+	flags.Bool(operatorOption.VolcengineReleaseExcessIPs, false, "Enable releasing excess free IP addresses from Volcengine ENI.")
+	option.BindEnv(vp, operatorOption.VolcengineReleaseExcessIPs)
+
+	vp.BindEnv(flags)
+}

--- a/operator/cmd/provider_volcengine_register.go
+++ b/operator/cmd/provider_volcengine_register.go
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+//go:build ipam_provider_volcengine
+
+package cmd
+
+import (
+	"github.com/cilium/cilium/pkg/ipam/allocator/volcengine"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
+)
+
+func init() {
+	allocatorProviders[ipamOption.IPAMVolcengine] = new(volcengine.AllocatorVolcengine)
+}

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -223,6 +223,26 @@ const (
 	// the number of API calls to AlibabaCloud ECS service.
 	AlibabaCloudReleaseExcessIPs = "alibaba-cloud-release-excess-ips"
 
+	// Volcengine options
+
+	// ENIGCTags is a tag that will be added to every ENI
+	// created by the Volcengine ENI IPAM.
+	// Any stale and unattached ENIs with this tag will be garbage
+	// collected by the operator.
+	ENIGCTags = "eni-gc-tags"
+
+	// ENIGCInterval defines the interval of ENI GC
+	ENIGCInterval = "eni-gc-interval"
+
+	// VolcengineVPCID allows user to specific vpc
+	VolcengineVPCID = "volcengine-cloud-vpc-id"
+
+	// VolcengineReleaseExcessIPs allows releasing excess free IP addresses from ENI.
+	// Enabling this option reduces waste of IP addresses but may increase
+	// the number of API calls to AlibabaCloud ECS service.
+	VolcengineReleaseExcessIPs = "volcengine-cloud-release-excess-ips"
+	//volcengine-release-excess-ips
+
 	// LoadBalancerL7 enables loadbalancer capabilities for services via envoy proxy
 	LoadBalancerL7 = "loadbalancer-l7"
 
@@ -427,6 +447,25 @@ type OperatorConfig struct {
 	// the number of API calls to AlibabaCloud ECS service.
 	AlibabaCloudReleaseExcessIPs bool
 
+	// Volcengine options
+
+	// ENIGCTags is a tag that will be added to every ENI
+	// created by the Volcengine ENI IPAM.
+	// Any stale and unattached ENIs with this tag will be garbage
+	// collected by the operator.
+	ENIGCTags map[string]string
+
+	// ENIGCInterval defines the interval of ENI GC
+	ENIGCInterval time.Duration
+
+	// VolcengineVPCID allow user to specific vpc
+	VolcengineVPCID string
+
+	// VolcengineReleaseExcessIPs allows releasing excess free IP addresses from ENI.
+	// Enabling this option reduces waste of IP addresses but may increase
+	// the number of API calls to Volcengine EC2 service.
+	VolcengineReleaseExcessIPs bool
+
 	// LoadBalancerL7 enables loadbalancer capabilities for services.
 	LoadBalancerL7 string
 
@@ -541,6 +580,11 @@ func (c *OperatorConfig) Populate(vp *viper.Viper) {
 	c.AlibabaCloudVPCID = vp.GetString(AlibabaCloudVPCID)
 	c.AlibabaCloudReleaseExcessIPs = vp.GetBool(AlibabaCloudReleaseExcessIPs)
 
+	// Volcengine options
+	c.VolcengineVPCID = vp.GetString(VolcengineVPCID)
+	c.VolcengineReleaseExcessIPs = vp.GetBool(VolcengineReleaseExcessIPs)
+	c.ENIGCInterval = vp.GetDuration(ENIGCInterval)
+
 	// Option maps and slices
 
 	if m := vp.GetStringSlice(IPAMSubnetsIDs); len(m) != 0 {
@@ -577,6 +621,12 @@ func (c *OperatorConfig) Populate(vp *viper.Viper) {
 		c.ENIGarbageCollectionTags = m
 	}
 
+	if m, err := command.GetStringMapStringE(vp, ENIGCTags); err != nil {
+		log.Fatalf("unable to parse %s: %s", ENIGCTags, err)
+	} else {
+		c.ENIGCTags = m
+	}
+
 	if m, err := command.GetStringMapStringE(vp, IPAMAutoCreateCiliumPodIPPools); err != nil {
 		log.Fatalf("unable to parse %s: %s", IPAMAutoCreateCiliumPodIPPools, err)
 	} else {
@@ -593,4 +643,6 @@ var Config = &OperatorConfig{
 	AWSInstanceLimitMapping:        make(map[string]string),
 	ENITags:                        make(map[string]string),
 	ENIGarbageCollectionTags:       make(map[string]string),
+
+	ENIGCTags: make(map[string]string),
 }

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -225,14 +225,14 @@ const (
 
 	// Volcengine options
 
-	// ENIGCTags is a tag that will be added to every ENI
+	// VolcengineENIGCTags is a tag that will be added to every ENI
 	// created by the Volcengine ENI IPAM.
 	// Any stale and unattached ENIs with this tag will be garbage
 	// collected by the operator.
-	ENIGCTags = "eni-gc-tags"
+	VolcengineENIGCTags = "eni-gc-tags"
 
-	// ENIGCInterval defines the interval of ENI GC
-	ENIGCInterval = "eni-gc-interval"
+	// VolcengineENIGCInterval defines the interval of ENI GC
+	VolcengineENIGCInterval = "eni-gc-interval"
 
 	// VolcengineVPCID allows user to specific vpc
 	VolcengineVPCID = "volcengine-cloud-vpc-id"
@@ -449,14 +449,14 @@ type OperatorConfig struct {
 
 	// Volcengine options
 
-	// ENIGCTags is a tag that will be added to every ENI
+	// VolcengineENIGCTags is a tag that will be added to every ENI
 	// created by the Volcengine ENI IPAM.
 	// Any stale and unattached ENIs with this tag will be garbage
 	// collected by the operator.
-	ENIGCTags map[string]string
+	VolcengineENIGCTags map[string]string
 
-	// ENIGCInterval defines the interval of ENI GC
-	ENIGCInterval time.Duration
+	// VolcengineENIGCInterval defines the interval of ENI GC
+	VolcengineENIGCInterval time.Duration
 
 	// VolcengineVPCID allow user to specific vpc
 	VolcengineVPCID string
@@ -583,7 +583,7 @@ func (c *OperatorConfig) Populate(vp *viper.Viper) {
 	// Volcengine options
 	c.VolcengineVPCID = vp.GetString(VolcengineVPCID)
 	c.VolcengineReleaseExcessIPs = vp.GetBool(VolcengineReleaseExcessIPs)
-	c.ENIGCInterval = vp.GetDuration(ENIGCInterval)
+	c.VolcengineENIGCInterval = vp.GetDuration(VolcengineENIGCInterval)
 
 	// Option maps and slices
 
@@ -621,10 +621,10 @@ func (c *OperatorConfig) Populate(vp *viper.Viper) {
 		c.ENIGarbageCollectionTags = m
 	}
 
-	if m, err := command.GetStringMapStringE(vp, ENIGCTags); err != nil {
-		log.Fatalf("unable to parse %s: %s", ENIGCTags, err)
+	if m, err := command.GetStringMapStringE(vp, VolcengineENIGCTags); err != nil {
+		log.Fatalf("unable to parse %s: %s", VolcengineENIGCTags, err)
 	} else {
-		c.ENIGCTags = m
+		c.VolcengineENIGCTags = m
 	}
 
 	if m, err := command.GetStringMapStringE(vp, IPAMAutoCreateCiliumPodIPPools); err != nil {
@@ -644,5 +644,5 @@ var Config = &OperatorConfig{
 	ENITags:                        make(map[string]string),
 	ENIGarbageCollectionTags:       make(map[string]string),
 
-	ENIGCTags: make(map[string]string),
+	VolcengineENIGCTags: make(map[string]string),
 }

--- a/pkg/ipam/allocator/volcengine/volcengine.go
+++ b/pkg/ipam/allocator/volcengine/volcengine.go
@@ -34,8 +34,8 @@ type AllocatorVolcengine struct {
 
 func (a *AllocatorVolcengine) buildENIGarbageCollectionTags(ctx context.Context, cfg *operatorOption.OperatorConfig) {
 	// Use user-provided tags if available
-	if len(cfg.ENIGCTags) != 0 {
-		a.eniGCTags = cfg.ENIGCTags
+	if len(cfg.VolcengineENIGCTags) != 0 {
+		a.eniGCTags = cfg.VolcengineENIGCTags
 		return
 	}
 
@@ -49,6 +49,7 @@ func (a *AllocatorVolcengine) buildENIGarbageCollectionTags(ctx context.Context,
 	if clusterName := option.Config.ClusterName; clusterName != defaults.ClusterName {
 		a.eniGCTags[defaults.ENIGarbageCollectionTagClusterName] = clusterName
 	}
+	// TODO:determine cluster tag if cluster-name not set
 }
 
 // Init sets up ENI limits based on given options
@@ -105,7 +106,7 @@ func (a *AllocatorVolcengine) Start(ctx context.Context, getterUpdater ipam.Cili
 		return nil, fmt.Errorf("unable to initialize Volcengine node manager: %w", err)
 	}
 
-	if cfg.ENIGCInterval > 0 {
+	if cfg.VolcengineENIGCInterval > 0 {
 		eni.StartENIGarbageCollector(ctx, a.client, eni.GarbageCollectionParams{
 			RunInterval:    cfg.EndpointGCInterval,
 			MaxPerInterval: defaults.ENIGarbageCollectionMaxPerInterval,

--- a/pkg/ipam/allocator/volcengine/volcengine.go
+++ b/pkg/ipam/allocator/volcengine/volcengine.go
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package volcengine
+
+import (
+	"context"
+	"fmt"
+
+	operatorMetrics "github.com/cilium/cilium/operator/metrics"
+	operatorOption "github.com/cilium/cilium/operator/option"
+	apiMetrics "github.com/cilium/cilium/pkg/api/metrics"
+	"github.com/cilium/cilium/pkg/defaults"
+	"github.com/cilium/cilium/pkg/ipam"
+	"github.com/cilium/cilium/pkg/ipam/allocator"
+	ipamMetrics "github.com/cilium/cilium/pkg/ipam/metrics"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/volcengine/api"
+	"github.com/cilium/cilium/pkg/volcengine/constant"
+	"github.com/cilium/cilium/pkg/volcengine/eni"
+	"github.com/cilium/cilium/pkg/volcengine/eni/limits"
+	"github.com/cilium/cilium/pkg/volcengine/metadata"
+)
+
+var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "ipam-allocator-volcengine")
+
+type AllocatorVolcengine struct {
+	client    api.VolcengineClient
+	eniGCTags map[string]string
+}
+
+func (a *AllocatorVolcengine) buildENIGarbageCollectionTags(ctx context.Context, cfg *operatorOption.OperatorConfig) {
+	// Use user-provided tags if available
+	if len(cfg.ENIGCTags) != 0 {
+		a.eniGCTags = cfg.ENIGCTags
+		return
+	}
+
+	// Use cilium managed garbage collection tag by default
+	a.eniGCTags = map[string]string{
+		defaults.ENIGarbageCollectionTagManagedName: defaults.ENIGarbageCollectionTagManagedValue,
+		defaults.ENIGarbageCollectionTagClusterName: defaults.ENIGarbageCollectionTagClusterValue,
+	}
+
+	// Use cilium cluster name if available
+	if clusterName := option.Config.ClusterName; clusterName != defaults.ClusterName {
+		a.eniGCTags[defaults.ENIGarbageCollectionTagClusterName] = clusterName
+	}
+}
+
+// Init sets up ENI limits based on given options
+func (a *AllocatorVolcengine) Init(ctx context.Context) (err error) {
+	metric := api.NewMetric()
+	cfg := operatorOption.Config
+
+	if cfg.EnableMetrics {
+		metric = apiMetrics.NewPrometheusMetrics(metrics.Namespace, constant.Volcengine, operatorMetrics.Registry)
+	}
+
+	vpcID := cfg.VolcengineVPCID
+	if len(vpcID) < 1 {
+		if vpcID, err = metadata.GetVPCID(ctx); err != nil {
+			log.Debugf("get vpc id from metadata of Volcengine failed: %v", err)
+			return err
+		}
+	}
+	regionID, err := metadata.GetRegionID(ctx)
+	if err != nil {
+		log.Debugf("get region id from metadata of Volcengine failed: %v", err)
+		return err
+	}
+
+	a.client, err = api.NewClient(regionID, vpcID, metric, cfg.IPAMAPIQPSLimit, cfg.IPAMAPIBurst,
+		map[string]string{constant.TagKeyVPCID: vpcID})
+	if err != nil {
+		log.Debugf("create client by %s.%s of Volcengine fialed: %v", regionID, vpcID, err)
+		return err
+	}
+
+	if err = limits.UpdateFromAPI(ctx, a.client); err != nil {
+		return fmt.Errorf("unable to update instance type to add adapter limits form Volcengine API: %w", err)
+	}
+
+	return nil
+}
+
+// Start kicks of ENI allocation, the initial connection to Volcengine
+// APIs is done in a blocking manner, given that is successful, a controller is
+// started to manage allocation based on CiliumNode custom resources
+func (a *AllocatorVolcengine) Start(ctx context.Context, getterUpdater ipam.CiliumNodeGetterUpdater) (allocator.NodeEventHandler, error) {
+	log.Info("Starting Volcengine ENI allocator...")
+
+	var metric ipam.MetricsAPI = new(ipamMetrics.NoOpMetrics)
+	cfg := operatorOption.Config
+	if cfg.EnableMetrics {
+		metric = ipamMetrics.NewPrometheusMetrics(metrics.Namespace, operatorMetrics.Registry)
+	}
+
+	im := eni.NewInstancesManager(a.client)
+	nm, err := ipam.NewNodeManager(im, getterUpdater, metric, cfg.ParallelAllocWorkers, cfg.VolcengineReleaseExcessIPs, false)
+	if err != nil {
+		return nil, fmt.Errorf("unable to initialize Volcengine node manager: %w", err)
+	}
+
+	if cfg.ENIGCInterval > 0 {
+		eni.StartENIGarbageCollector(ctx, a.client, eni.GarbageCollectionParams{
+			RunInterval:    cfg.EndpointGCInterval,
+			MaxPerInterval: defaults.ENIGarbageCollectionMaxPerInterval,
+			ENITags:        a.eniGCTags,
+		})
+	}
+
+	return nm, nm.Start(ctx)
+}

--- a/pkg/ipam/option/option.go
+++ b/pkg/ipam/option/option.go
@@ -29,6 +29,9 @@ const (
 	// IPAMAlibabaCloud is the value to select the AlibabaCloud ENI IPAM plugin for option.IPAM
 	IPAMAlibabaCloud = "alibabacloud"
 
+	// IPAMVolcengine is the value to select the Volcengine ENI IPAM plugin for option.IPAM
+	IPAMVolcengine = "volcengine"
+
 	// IPAMDelegatedPlugin is the value to select CNI delegated IPAM plugin mode.
 	// In this mode, Cilium CNI invokes another CNI binary (the delegated plugin) for IPAM.
 	// See https://www.cni.dev/docs/spec/#section-4-plugin-delegation

--- a/pkg/volcengine/api/api.go
+++ b/pkg/volcengine/api/api.go
@@ -1,0 +1,32 @@
+package api
+
+import (
+	"context"
+
+	"github.com/volcengine/volcengine-go-sdk/service/ecs"
+
+	"github.com/cilium/cilium/pkg/volcengine/eni"
+)
+
+// VolcengineClient is a subset of Volcengine Open API method
+type VolcengineClient interface {
+	eni.VolcengineAPI
+	GetInstanceTypes(ctx context.Context) ([]ecs.InstanceTypeForDescribeInstanceTypesOutput, error)
+}
+
+// client implemented VolcengineClient for open api call
+type client struct {
+	eni.VolcengineAPI
+}
+
+func (c client) GetInstanceTypes(ctx context.Context) ([]ecs.InstanceTypeForDescribeInstanceTypesOutput, error) {
+	return nil, nil
+}
+
+func NewClient(regionID, vpcID string, metric VolcengineMetric, qpsLimit float64, burst int, filters map[string]string) (VolcengineClient, error) {
+	return newClient()
+}
+
+func newClient() (*client, error) {
+	return &client{}, nil
+}

--- a/pkg/volcengine/api/metric.go
+++ b/pkg/volcengine/api/metric.go
@@ -1,0 +1,15 @@
+package api
+
+import (
+	"github.com/cilium/cilium/pkg/api/helpers"
+	apiMetrics "github.com/cilium/cilium/pkg/api/metrics"
+)
+
+type VolcengineMetric interface {
+	helpers.MetricsAPI
+	ObserveAPICall(call, status string, duration float64)
+}
+
+func NewMetric() VolcengineMetric {
+	return &apiMetrics.NoOpMetrics{}
+}

--- a/pkg/volcengine/constant/constant.go
+++ b/pkg/volcengine/constant/constant.go
@@ -1,6 +1,10 @@
 package constant
 
 const (
+	Volcengine = "volcengine"
+)
+
+const (
 	LogFieldENID               = "eniID"
 	LogFieldSubnetID           = "subnetID"
 	LogFieldAddresses          = "addresses"
@@ -13,4 +17,8 @@ const (
 	LogFieldUsedAddressesCount = "usedAddressesCount"
 	LogFieldExcessIPs          = "excessIPs"
 	LogFieldFreeOnENICount     = "freeOnENICount"
+)
+
+const (
+	TagKeyVPCID = "VPCID"
 )

--- a/pkg/volcengine/eni/gc.go
+++ b/pkg/volcengine/eni/gc.go
@@ -1,0 +1,23 @@
+package eni
+
+import (
+	"context"
+	"time"
+
+	"github.com/cilium/cilium/pkg/ipam/types"
+)
+
+type GarbageCollectionParams struct {
+	// RunInterval is both the GC interval and also the minimum amount of time
+	// an ENI has to be available before it is garbage collected
+	RunInterval time.Duration
+	// MaxPerInterval is the maximum number of ENIs which are deleted in a
+	// single interval
+	MaxPerInterval int32
+	// ENITags is used to only garbage collect ENIs with this set of tags
+	ENITags types.Tags
+}
+
+func StartENIGarbageCollector(ctx context.Context, api VolcengineAPI, params GarbageCollectionParams) {
+	log.Info("Starting to garbage collect detached ENIs")
+}

--- a/pkg/volcengine/eni/instances.go
+++ b/pkg/volcengine/eni/instances.go
@@ -13,6 +13,7 @@ import (
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/time"
+	"github.com/cilium/cilium/pkg/volcengine/constant"
 	eniTypes "github.com/cilium/cilium/pkg/volcengine/eni/types"
 	"github.com/cilium/cilium/pkg/volcengine/types"
 )
@@ -169,15 +170,15 @@ func (m *InstancesManager) resync(ctx context.Context, instanceID string) time.T
 	} else {
 		instance, err := m.api.GetInstance(ctx, vpcs, subnets, instanceID)
 		if err != nil {
-			log.WithError(err).WithField(fieldENIID, instanceID).Warning("Unable to synchronize instance")
+			log.WithError(err).WithField(constant.LogFieldENID, instanceID).Warning("Unable to synchronize instance")
 			return time.Time{}
 		}
 
 		log.WithFields(logrus.Fields{
-			fieldInstanceID:     instanceID,
-			"numVPCs":           len(vpcs),
-			"numSubnets":        len(subnets),
-			"numSecurityGroups": len(securityGroups),
+			constant.LogFieldInstanceID: instanceID,
+			"numVPCs":                   len(vpcs),
+			"numSubnets":                len(subnets),
+			"numSecurityGroups":         len(securityGroups),
 		}).Info("Synchronized ENI information for the corresponding instance")
 
 		m.mutex.Lock()

--- a/pkg/volcengine/eni/limits/limits.go
+++ b/pkg/volcengine/eni/limits/limits.go
@@ -4,8 +4,11 @@
 package limits
 
 import (
+	"context"
+
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/volcengine/api"
 )
 
 // limits contains limits for adapter count and addresses. The mappings will be
@@ -24,4 +27,8 @@ func Get(instanceType string) (limit ipamTypes.Limits, ok bool) {
 	limit, ok = limits.m[instanceType]
 	limits.RUnlock()
 	return
+}
+
+func UpdateFromAPI(ctx context.Context, ec2 api.VolcengineClient) error {
+	return nil
 }

--- a/pkg/volcengine/eni/log.go
+++ b/pkg/volcengine/eni/log.go
@@ -6,13 +6,9 @@ package eni
 import (
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/volcengine/constant"
 )
 
 var (
-	log = logging.DefaultLogger.WithField(logfields.LogSubsys, "volcengine")
-)
-
-const (
-	fieldENIID      = "eniID"
-	fieldInstanceID = "instanceID"
+	log = logging.DefaultLogger.WithField(logfields.LogSubsys, constant.Volcengine)
 )

--- a/pkg/volcengine/metadata/metadata.go
+++ b/pkg/volcengine/metadata/metadata.go
@@ -1,0 +1,11 @@
+package metadata
+
+import "context"
+
+func GetVPCID(ctx context.Context) (string, error) {
+	return "", nil
+}
+
+func GetRegionID(ctx context.Context) (string, error) {
+	return "", nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1169,6 +1169,35 @@ github.com/vishvananda/netlink/nl
 # github.com/vishvananda/netns v0.0.4
 ## explicit; go 1.17
 github.com/vishvananda/netns
+# github.com/volcengine/volc-sdk-golang v1.0.23
+## explicit; go 1.14
+github.com/volcengine/volc-sdk-golang/base
+github.com/volcengine/volc-sdk-golang/service/sts
+# github.com/volcengine/volcengine-go-sdk v1.0.124
+## explicit; go 1.12
+github.com/volcengine/volcengine-go-sdk/internal/ini
+github.com/volcengine/volcengine-go-sdk/internal/sdkio
+github.com/volcengine/volcengine-go-sdk/internal/sdkmath
+github.com/volcengine/volcengine-go-sdk/internal/sdkrand
+github.com/volcengine/volcengine-go-sdk/internal/shareddefaults
+github.com/volcengine/volcengine-go-sdk/private/protocol
+github.com/volcengine/volcengine-go-sdk/private/protocol/query/queryutil
+github.com/volcengine/volcengine-go-sdk/service/ecs
+github.com/volcengine/volcengine-go-sdk/volcengine
+github.com/volcengine/volcengine-go-sdk/volcengine/client
+github.com/volcengine/volcengine-go-sdk/volcengine/client/metadata
+github.com/volcengine/volcengine-go-sdk/volcengine/corehandlers
+github.com/volcengine/volcengine-go-sdk/volcengine/credentials
+github.com/volcengine/volcengine-go-sdk/volcengine/custom
+github.com/volcengine/volcengine-go-sdk/volcengine/endpoints
+github.com/volcengine/volcengine-go-sdk/volcengine/request
+github.com/volcengine/volcengine-go-sdk/volcengine/response
+github.com/volcengine/volcengine-go-sdk/volcengine/signer/volc
+github.com/volcengine/volcengine-go-sdk/volcengine/special
+github.com/volcengine/volcengine-go-sdk/volcengine/volcenginebody
+github.com/volcengine/volcengine-go-sdk/volcengine/volcengineerr
+github.com/volcengine/volcengine-go-sdk/volcengine/volcenginequery
+github.com/volcengine/volcengine-go-sdk/volcengine/volcengineutil
 # github.com/yusufpapurcu/wmi v1.2.3
 ## explicit; go 1.16
 github.com/yusufpapurcu/wmi


### PR DESCRIPTION
support gc tags by user custom or cilium managed by default, but not support VKE (Volcengine K8s Engine) cluster tags detect

Signed-off-by: Jinzhu Lee <lijinzhu.azl@bytedance.com>